### PR TITLE
Rename MultRowVector to MultVector

### DIFF
--- a/doc/vectors.xml
+++ b/doc/vectors.xml
@@ -317,8 +317,8 @@ For a <C>cvec</C> <A>v</A>. Works as expected.
 </ManSection>
 
 <ManSection>
-<Meth Name="MultRowVector" Arg="v, s" Label="cvecsca"/>
-<Meth Name="MultRowVector" Arg="v, s, fr, to" Label="cvecscapospos"/>
+<Meth Name="MultVector" Arg="v, s" Label="cvecsca"/>
+<Meth Name="MultVector" Arg="v, s, fr, to" Label="cvecscapospos"/>
 <Returns>nothing</Returns>
 <Description>
     <A>v</A> must be a mutable <C>cvec</C> and <A>s</A> a scalar (see

--- a/gap/cmat.gi
+++ b/gap/cmat.gi
@@ -2411,7 +2411,7 @@ end);
 InstallGlobalFunction(CVEC_MulMat, function(a,mult)
   local i;
   for i in [1..Length(a)] do
-      MultRowVector(a[i],mult);
+      MultVector(a[i],mult);
   od;
 end);
 
@@ -2559,7 +2559,7 @@ InstallGlobalFunction( CVEC_MultiplyWinogradMemory, function(M,N,limit)
   #      NumberColumns(N),"\n");
 
   ClearLastRow := function(m)
-      MultRowVector(m[NumberRows(m)],Zero(BaseDomain(m)));
+      MultVector(m[NumberRows(m)],Zero(BaseDomain(m)));
   end;
   ClearLastColumn := function(m)
       local i,r,z;
@@ -2737,7 +2737,7 @@ InstallGlobalFunction( CVEC_ValueLaurentPoly,
     n := Length(x);
     s := f[1][i];
     if not(IsOne(s)) then
-        for j in [1..n] do MultRowVector(val[j],s); od;
+        for j in [1..n] do MultVector(val[j],s); od;
     fi;
     o := One(BaseField(x));
     while true do

--- a/gap/cvec.gi
+++ b/gap/cvec.gi
@@ -483,29 +483,29 @@ InstallOtherMethod( AddRowVector, "for cvecs",
   [IsMutable and IsCVecRep,IsCVecRep,IsFFE and IsInternalRep,IsInt,IsInt],
   CVEC_ADDMUL );
 
-# MultRowVector(v,s [,fr,to]) where s is integer or FFE:
-# Note that we do not give a method for MultRowVector with 5 arguments!
+# MultVector(v,s [,fr,to]) where s is integer or FFE:
+# Note that we do not give a method for MultVector with 5 arguments!
 
-InstallOtherMethod( MultRowVector, "for cvecs",
+InstallOtherMethod( MultVector, "for cvecs",
   [IsMutable and IsCVecRep, IsInt and IsSmallIntRep],
   function(v,s) CVEC_MUL1(v,s,0,0); end);
-InstallOtherMethod( MultRowVector, "for cvecs",
+InstallOtherMethod( MultVector, "for cvecs",
   [IsMutable and IsCVecRep, IsInt and IsSmallIntRep, IsInt, IsInt],
   CVEC_MUL1 );
 
-InstallOtherMethod( MultRowVector, "for cvecs",
+InstallOtherMethod( MultVector, "for cvecs",
   [IsMutable and IsCVecRep, IsFFE and IsInternalRep],
   function(v,s) CVEC_MUL1(v,s,0,0); end);
-InstallOtherMethod( MultRowVector, "for cvecs",
+InstallOtherMethod( MultVector, "for cvecs",
   [IsMutable and IsCVecRep, IsFFE and IsInternalRep, IsInt, IsInt],
   CVEC_MUL1 );
 
-InstallOtherMethod( MultRowVector, "for cvecs",
+InstallOtherMethod( MultVector, "for cvecs",
   [IsMutable and IsCVecRep, IsFFE],
   function(v,s) 
     CVEC_MUL1(v,CVEC_HandleScalar(DataObj(v),s),0,0);
   end);
-InstallOtherMethod( MultRowVector, "for cvecs",
+InstallOtherMethod( MultVector, "for cvecs",
   [IsMutable and IsCVecRep, IsFFE, IsInt, IsInt],
   function(v,s,fr,to) 
     CVEC_MUL1(v,CVEC_HandleScalar(DataObj(v),s),fr,to);

--- a/gap/linalg.gi
+++ b/gap/linalg.gi
@@ -134,7 +134,7 @@ BindGlobal( "CVEC_CleanRow", function( basis, vec, extend, dec)
 
   # Clear dec vector if given:
   if dec <> fail then
-    MultRowVector(dec,Zero(dec[1]));
+    MultVector(dec,Zero(dec[1]));
   fi;
   
   # First a little shortcut:
@@ -170,7 +170,7 @@ BindGlobal( "CVEC_CleanRow", function( basis, vec, extend, dec)
       if dec <> fail then
         dec[len+1] := c;
       fi;
-      MultRowVector( vec, c^-1 );
+      MultVector( vec, c^-1 );
       Add( basis!.vectors, vec );
       Add( basis!.pivots, newpiv );
     fi;
@@ -1094,9 +1094,9 @@ function( arg )
           #                   = Y[l] - dec{[1..l-1]}*B*Y{[1..l-1]}
           # by a slight abuse of "*" because dec{[1..l-1]}*B has full length.
           newBrow := dec{[1..l-1]}*B;
-          MultRowVector(newBrow,-opi.o);
+          MultVector(newBrow,-opi.o);
           newBrow[l] := opi.o;
-          MultRowVector(newBrow,dec[l]^-1);
+          MultVector(newBrow,dec[l]^-1);
           Add(B,newBrow);
       od;
       # Now we have extended the basis S together with A and B, such that

--- a/gap/matrix.gi
+++ b/gap/matrix.gi
@@ -17,7 +17,7 @@
 
 # SemiEchelonMat and friends:
 # (note that we basically copy the library method, but use advanced
-#  functionality of AddRowVector and MultRowVectors here):
+#  functionality of AddRowVector and MultVectors here):
 
 InstallMethod( SemiEchelonMatDestructive, "for a cmat",
     [ IsMutable and IsCMatRep ],
@@ -56,7 +56,7 @@ InstallMethod( SemiEchelonMatDestructive, "for a cmat",
             if inv = fail then
               return fail;
             fi;
-            MultRowVector( row, inv, j, ncols );
+            MultVector( row, inv, j, ncols );
             Add( vectors, row );
             Add( nzheads, j );
             heads[j]:= Length( vectors );

--- a/init.g
+++ b/init.g
@@ -25,6 +25,9 @@ fi;
 #
 # Compatibility between older and newer versions of the MatrixObj interface
 #
+if not IsBound(MultVector) then
+    DeclareSynonym( "MultVector", MultRowVector );
+fi;
 if not IsBound(NumberColumns) then
     DeclareSynonymAttr( "NumberColumns", RowLength );
     DeclareSynonymAttr( "NumberRows", Length );

--- a/test/matobjtest.g
+++ b/test/matobjtest.g
@@ -160,9 +160,9 @@ RowListMatrixObjTester := function( m, level )
   for i in [1..l] do if u[i] <> w[i]*three then MyError(31); fi; od;
   AddRowVector(u,w,-two,1,l);
   if u <> w then MyError(32); fi;
-  MultRowVector(u,two);
+  MultVector(u,two);
   for i in [1..l] do if u[i] <> w[i]*two then MyError(33); fi; od;
-  MultRowVector(u,[1,2],w,[2,1],two);
+  MultVector(u,[1,2],w,[2,1],two);
   if u[1] <> w[2]*two or u[2] <> w[1]*two then MyError(34); fi;
   if w/one <> w then MyError(35); fi;
 


### PR DESCRIPTION
Adjusts to changes in GAP's new IsMatrixObj interface.
This is kept compatible with GAP versions using the old interface by
declaring appropriate synonyms.