### PR TITLE
Update Randomize installation to future GAP versions

### DIFF
--- a/gap/cmat.gi
+++ b/gap/cmat.gi
@@ -514,21 +514,21 @@ InstallMethod( Unpack, "for a cmat", [IsCMatRep],
 # (Pseudo) random matrices:
 
 InstallMethod( Randomize, "for a cmat", [ IsCMatRep and IsMutable ],
-  function( m )
-    local i;
-    for i in [2..m!.len+1] do
-      Randomize(m!.rows[i]);
-    od;
-  end );
+    m -> Randomize(GlobalMersenneTwister, m) );
 
-InstallMethod( Randomize, "for a cmat and a random source", 
-  [ IsCMatRep and IsMutable, IsRandomSource ],
+InstallOtherMethod( Randomize, "for a cmat and a random source",
+  [ IsRandomSource, IsCMatRep and IsMutable ],
   function( m, rs )
     local i;
     for i in [2..m!.len+1] do
-      Randomize(m!.rows[i],rs);
+      Randomize(rs, m!.rows[i]);
     od;
   end );
+
+# for compatibility with GAP < 4.11
+InstallOtherMethod( Randomize, "for a cmat and a random source",
+  [ IsCMatRep and IsMutable, IsRandomSource ],
+    { m, rs } -> Randomize( rs, m ) );
 
 #############################################################################
 # PostMakeImmutable to make subobjects immutable:

--- a/gap/cvec.gi
+++ b/gap/cvec.gi
@@ -1212,33 +1212,11 @@ end);
 ############################################################################
 
 InstallMethod( Randomize, "for cvecs", [IsCVecRep and IsMutable],
-  function( v )
-    local cl,d,j,len,li,p,q,size;
-    cl := DataObj(v);
-    len := Length(v);
-    size := cl![CVEC_IDX_fieldinfo]![CVEC_IDX_size];
-    d := cl![CVEC_IDX_fieldinfo]![CVEC_IDX_d];
-    if size <= 1 then
-        q := cl![CVEC_IDX_fieldinfo]![CVEC_IDX_q];
-        li := 0*[1..len];
-        for j in [1..len] do
-            li[j] := Random(0,q-1);
-        od;
-        CVEC_INTREP_TO_CVEC(li,v);
-    else    # big scalars!
-        li := 0*[1..len*d];
-        p := cl![CVEC_IDX_fieldinfo]![CVEC_IDX_p];
-        for j in [1..len*d] do
-            li[j] := Random(0,p-1);
-        od;
-        CVEC_INTREP_TO_CVEC(li,v);
-    fi;
-    return v;
-  end );
+    v -> Randomize(GlobalMersenneTwister, v) );
 
-InstallMethod( Randomize, "for a cvec and a random source", 
-  [IsCVecRep and IsMutable, IsRandomSource],
-  function( v, rs )
+InstallOtherMethod( Randomize, "for a random source and a cvec",
+  [IsRandomSource, IsCVecRep and IsMutable],
+  function( rs, v )
     local cl,d,j,len,li,p,q,size;
     cl := DataObj(v);
     len := Length(v);
@@ -1261,6 +1239,11 @@ InstallMethod( Randomize, "for a cvec and a random source",
     fi;
     return v;
   end );
+
+# for compatibility with GAP < 4.11
+InstallOtherMethod( Randomize, "for a cvec and a random source",
+  [IsCVecRep and IsMutable, IsRandomSource],
+    { v, rs } -> Randomize( rs, v ) );
 
 
 #############################################################################


### PR DESCRIPTION
The order of the random source and the matrix/vector will be swapped, to match
the order used by `Random` and other similar functions. The code in this
commit should work equally well with old and new GAP versions.