### PR TITLE
Fix an error converting large fields to cvec

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,9 @@
 This file describes changes in the cvec package.
 
+X.Y (2022-MM-DD)
+  - Fix a bug converting vectors defined over large (non-internal) finite fields
+    to cvec format
+
 2.7.5 (2021-09-06)
   - Require GAP version >= 4.10
   - Replace buildsystem with the "standard GAP package buildsystem"

--- a/gap/cvec.gi
+++ b/gap/cvec.gi
@@ -413,8 +413,13 @@ InstallGlobalFunction( CVEC_HandleScalar, function(cl,s)
   fi;
   # Now we have to check, whether the field element is over the right field:
   d := cl![CVEC_IDX_fieldinfo]![CVEC_IDX_d];
-  if s![2] <> d then
+  if s![2] < d then
       s := FFECONWAY.WriteOverLargerField(s,d);
+  elif s![2] > d then
+      s := FFECONWAY.TryToWriteInSmallerField(s,d);
+      # s now could be internal
+      if IsInternalRep(s) then return s; fi;
+      if s = fail then Error("input vector not defined over the expected field"); fi;
   fi;
   if IsGF2VectorRep(s![1]) then
     v := ShallowCopy(s![1]);

--- a/tst/conversion.tst
+++ b/tst/conversion.tst
@@ -1,3 +1,6 @@
+gap> START_TEST("conversion.tst");
+
+#
 gap> m2 := [ 0 * Z(2), Z(2)^0 ];
 [ 0*Z(2), Z(2)^0 ]
 gap> m4 := [ 0 * Z(4), Z(4)^0 ];
@@ -76,3 +79,11 @@ gap> cmat2 := NewMatrix(IsCMatRep,GF(5),Length(mat2[1]),mat2);
 <cmat 2x2 over GF(5,1)>
 gap> cmat = cmat2;
 true
+
+# The following used to give an error.
+# See https://github.com/gap-packages/FinInG/issues/21
+gap> CVec([0*Z(2^18)], 2, 1);
+<cvec over GF(2,1) of length 1>
+
+#
+gap> STOP_TEST("conversion.tst", 0);


### PR DESCRIPTION
This happened when an FFE was defined in a large (not internal) field
but lived in a smaller subfield. In that case conversion of vectors to
cvec format could fail