### PR TITLE
adjust to changes in GAP

### DIFF
--- a/gap/cmat.gi
+++ b/gap/cmat.gi
@@ -44,10 +44,9 @@ InstallMethod( ConstructingFilter, "for a cmat",
   [ IsCMatRep ],
   function( m ) return IsCMatRep; end );
 
-InstallMethod( NewMatrix, 
-  "for IsCMatRep, a finite field, an integer, and finite field data",
-  [ IsCMatRep, IsField and IsFinite, IsInt, IsList ],
-  function( filt, f, rl, l )
+# `NewMatrix` was a constructor
+# in GAP <= 4.12 but is a tag based operation in GAP 4.13.
+Perform( [ function( filt, f, rl, l )
     local p,d,c,li,i,v;
     p := Characteristic(f);
     d := DegreeOverPrimeField(f);
@@ -66,12 +65,24 @@ InstallMethod( NewMatrix,
         fi;
     od;
     return CVEC_CMatMaker(li,c);
-  end);
+  end ],
+  function( method )
+    if IS_CONSTRUCTOR( NewMatrix ) then
+      # This holds in GAP <= 4.12.
+      InstallMethod( NewMatrix,
+        [ "IsCMatRep", "IsField and IsFinite", "IsInt", "IsList" ], method );
+    elif IsBoundGlobal( "InstallTagBasedMethod" ) then
+      # This should hold in GAP 4.13.
+      ValueGlobal("InstallTagBasedMethod")( NewMatrix, IsCMatRep, method );
+    else
+      # This should not happen.
+      Error( "NewMatrix is neither a constructor not a tag based operation" );
+    fi;
+  end );
 
-InstallMethod( NewZeroMatrix,
-  "for IsCMatRep, a finite field, and two integers",
-  [ IsCMatRep, IsField and IsFinite, IsInt, IsInt ],
-  function( filt, f, rows, cols )
+# `NewZeroMatrix` was a constructor
+# in GAP <= 4.12 but is a tag based operation in GAP 4.13.
+Perform( [ function( filt, f, rows, cols )
     local p, d, c, li, i;
     p := Characteristic(f);
     d := DegreeOverPrimeField(f);
@@ -81,12 +92,24 @@ InstallMethod( NewZeroMatrix,
         li[i] := CVEC_NEW(c,c![CVEC_IDX_type]);
     od;
     return CVEC_CMatMaker(li,c);
+  end ],
+  function( method )
+    if IS_CONSTRUCTOR( NewZeroMatrix ) then
+      # This holds in GAP <= 4.12.
+      InstallMethod( NewZeroMatrix,
+        [ "IsCMatRep", "IsField and IsFinite", "IsInt", "IsInt" ], method );
+    elif IsBoundGlobal( "InstallTagBasedMethod" ) then
+      # This should hold in GAP 4.13.
+      ValueGlobal("InstallTagBasedMethod")( NewZeroMatrix, IsCMatRep, method );
+    else
+      # This should not happen.
+      Error( "NewZeroMatrix is neither a constructor not a tag based operation" );
+    fi;
   end );
-    
-InstallMethod( NewIdentityMatrix,
-  "for IsCMatRep, a finite field, and an integer",
-  [ IsCMatRep, IsField and IsFinite, IsInt ],
-  function( filt, f, rows )
+
+# `NewIdentityMatrix` was a constructor
+# in GAP <= 4.12 but is a tag based operation in GAP 4.13.
+Perform( [ function( filt, f, rows )
     local p, d, c, li, o, i;
     p := Characteristic(f);
     d := DegreeOverPrimeField(f);
@@ -98,8 +121,20 @@ InstallMethod( NewIdentityMatrix,
         li[i+1,i] := o;
     od;
     return CVEC_CMatMaker(li,c);
+  end ],
+  function( method )
+    if IS_CONSTRUCTOR( NewIdentityMatrix ) then
+      # This holds in GAP <= 4.12.
+      InstallMethod( NewIdentityMatrix,
+        [ "IsCMatRep", "IsField and IsFinite", "IsInt" ], method );
+    elif IsBoundGlobal( "InstallTagBasedMethod" ) then
+      # This should hold in GAP 4.13.
+      ValueGlobal("InstallTagBasedMethod")( NewIdentityMatrix, IsCMatRep, method );
+    else
+      # This should not happen.
+      Error( "NewIdentityMatrix is neither a constructor not a tag based operation" );
+    fi;
   end );
-    
 
 InstallMethod( CMat, "for a list of cvecs and a cvec", [IsList, IsCVecRep],
   function(l,v)
@@ -341,10 +376,9 @@ InstallMethod( CompanionMatrix, "for a polynomial and a cmat",
     return CVEC_CMatMaker(ll,cl);
   end );
 
-InstallMethod( NewCompanionMatrix,
-  "for IsCMatRep, a polynomial and a ring",
-  [ IsCMatRep, IsUnivariatePolynomial, IsRing ],
-  function( ty, po, bd )
+# `NewCompanionMatrix` was a constructor
+# in GAP <= 4.12 but is a tag based operation in GAP 4.13.
+Perform( [ function( ty, po, bd )
     local i,l,ll,n,one;
     one := One(bd);
     l := CoefficientsOfUnivariatePolynomial(po);
@@ -364,6 +398,19 @@ InstallMethod( NewCompanionMatrix,
     od;
     Add(ll,l);
     return ll;
+  end ],
+  function( method )
+    if IS_CONSTRUCTOR( NewCompanionMatrix ) then
+      # This holds in GAP <= 4.12.
+      InstallMethod( NewCompanionMatrix,
+        [ "IsCMatRep", "IsUnivariatePolynomial", "IsRing" ], method );
+    elif IsBoundGlobal( "InstallTagBasedMethod" ) then
+      # This should hold in GAP 4.13.
+      ValueGlobal("InstallTagBasedMethod")( NewCompanionMatrix, IsCMatRep, method );
+    else
+      # This should not happen.
+      Error( "NewCompanionMatrix is neither a constructor not a tag based operation" );
+    fi;
   end );
 
 InstallGlobalFunction( CVEC_RandomMat, function(arg)

--- a/gap/cvec.gi
+++ b/gap/cvec.gi
@@ -343,7 +343,7 @@ InstallMethod( PrintObj, "for a cvec", [IsCVecRep],
 function(v)
   local l,c,i;
   c := DataObj(v);
-  Print("NewRowVector(IsCVecRep,GF(",c![CVEC_IDX_fieldinfo]![CVEC_IDX_p],",",
+  Print("NewVector(IsCVecRep,GF(",c![CVEC_IDX_fieldinfo]![CVEC_IDX_p],",",
         c![CVEC_IDX_fieldinfo]![CVEC_IDX_d],"),[");
   if c![CVEC_IDX_fieldinfo]![CVEC_IDX_size] = 0 then   # GAP FFEs
       l := Unpack(v);
@@ -359,7 +359,7 @@ InstallMethod( String, "for a cvec", [IsCVecRep],
 function(v)
   local l,c,i,res;
   c := DataObj(v);
-  res := "NewRowVector(IsCVecRep,GF(";
+  res := "NewVector(IsCVecRep,GF(";
   Append(res,String(c![CVEC_IDX_fieldinfo]![CVEC_IDX_p]));
   Add(res,',');
   Append(res,String(c![CVEC_IDX_fieldinfo]![CVEC_IDX_d]));
@@ -868,10 +868,9 @@ InstallMethod( ConstructingFilter, "for a cvec",
     return IsCVecRep;
   end );
 
-InstallMethod( NewRowVector, 
-  "for IsCVecRep, a finite field, and a list of finite field elements",
-  [IsCVecRep, IsField and IsFinite, IsList],
-  function( filt, f, l )
+# `NewVector` was a constructor
+# in GAP <= 4.12 but is a tag based operation in GAP 4.13.
+Perform( [ function( filt, f, l )
     local p,d,c;
     p := Characteristic(f);
     d := DegreeOverPrimeField(f);
@@ -881,17 +880,42 @@ InstallMethod( NewRowVector,
         c := CVEC_NewCVecClass(p,d,Length(l)/d);
     fi;
     return CVec(l,c);  # Delegate to another routine
+  end ],
+  function( method )
+    if IS_CONSTRUCTOR( NewVector ) then
+      # This holds in GAP <= 4.12.
+      InstallMethod( NewVector,
+        ["IsCVecRep", "IsField and IsFinite", "IsList"], method );
+    elif IsBoundGlobal( "InstallTagBasedMethod" ) then
+      # This should hold in GAP 4.13.
+      ValueGlobal("InstallTagBasedMethod")( NewVector, IsCVecRep, method );
+    else
+      # This should not happen.
+      Error( "NewVector is neither a constructor not a tag based operation" );
+    fi;
   end );
 
-InstallMethod( NewZeroVector,
-  "for IsCVecRep, a finite field, and an integer",
-  [ IsCVecRep, IsField and IsFinite, IsInt ],
-  function( filt, f, l )
+# `NewZeroVector` was a constructor
+# in GAP <= 4.12 but is a tag based operation in GAP 4.13.
+Perform( [ function( filt, f, l )
     local p,d,cl;
     p := Characteristic(f);
     d := DegreeOverPrimeField(f);
     cl := CVEC_NewCVecClass(p,d,l);
     return CVEC_NEW(cl,cl![CVEC_IDX_type]);
+  end ],
+  function( method )
+    if IS_CONSTRUCTOR( NewZeroVector ) then
+      # This holds in GAP <= 4.12.
+      InstallMethod( NewZeroVector,
+        ["IsCVecRep", "IsField and IsFinite", "IsInt"], method );
+    elif IsBoundGlobal( "InstallTagBasedMethod" ) then
+      # This should hold in GAP 4.13.
+      ValueGlobal("InstallTagBasedMethod")( NewZeroVector, IsCVecRep, method );
+    else
+      # This should not happen.
+      Error( "NewZeroVector is neither a constructor not a tag based operation" );
+    fi;
   end );
 
 InstallMethod( Vector, "for a list of finite field elements, and a cvec",


### PR DESCRIPTION
This pull request belongs to gap-system/gap/pull/5395:

When `NewCompanionMatrix`, `NewIdentityMatrix`, `NewMatrix`, `NewVector`, `NewZeroMatrix`, `NewZeroVector` are changed from constructors to tag based operations, the method installations in the cvec package must be adjusted.

The current proposal makes the cvec code compatible with the old and the new behaviour of the operations.

(Additionally, use `NewVector` not `NewRowVector`; the obsolescent synonym `NewRowVector` is still available in GAP but using only `NewVector` makes it easier to find out where the operation is used.)