### PR TITLE
Replace compiled.h by gap_all.h

### DIFF
--- a/src/cvec.c
+++ b/src/cvec.c
@@ -10,7 +10,7 @@
 
 #include <stdlib.h>
 
-#include "compiled.h" // GAP headers
+#include "gap_all.h" // GAP headers
 
 #ifdef SYS_IS_64_BIT
 #include "gf2lib_64.c"


### PR DESCRIPTION
No functional change for this package but makes it future-proof.
