### PR TITLE
Define `CompatibleVectorFilter` for `IsCMatRep`

### DIFF
--- a/gap/cmat.gd
+++ b/gap/cmat.gd
@@ -18,6 +18,8 @@ DeclareRepresentation( "IsCMatRep",
   IsComponentObjectRep and IsMatrix and IsOrdinaryMatrix and HasLength and
   IsRowListMatrix, [] );
 
+InstallMethod( CompatibleVectorFilter, ["IsCMatRep"],
+  M -> IsCVecRep );
 
 #############################################################################
 # Making of matrices:

--- a/tst/cmat.tst
+++ b/tst/cmat.tst
@@ -62,5 +62,11 @@ gap> Display(c9);
  [.12]
 ]
 
+# moved to the cvec tests from GAP's testbugfix/2012-06-18-t00327.tst
+gap> mat:= [ [ Z(2) ] ];;
+gap> ConvertToMatrixRep( mat, 2 );
+2
+gap> cmat:= CMat( mat );;  cmat^1000;;
+
 #
 gap> STOP_TEST("cmat.tst", 0);

--- a/tst/cmat.tst
+++ b/tst/cmat.tst
@@ -20,6 +20,8 @@ gap> NewZeroMatrix(IsCMatRep, GF(3), 3, 2);
 #
 gap> m:=CMat(ImmutableMatrix(GF(3),[[1,0],[0,1]]*Z(3)));
 <cmat 2x2 over GF(3,1)>
+gap> CompatibleVectorFilter(m) = ConstructingFilter(CompatibleVector(m));
+true
 gap> ScalarProductsRows(m,m,1);
 Z(3)^0
 gap> ScalarProductsRows(m,m,2);


### PR DESCRIPTION
This was missing up to now, see gap-system/gap/pull/6397.